### PR TITLE
Fix for database source

### DIFF
--- a/src/Pages/Template.php
+++ b/src/Pages/Template.php
@@ -267,7 +267,12 @@ abstract class Template implements ArrayAccess
         }
 
         if(!isset($this->attributes[$attribute]) && $this->throwOnMissing) {
-            $path = $this->getSource()->getFilePath($this->type, $this->name);
+            $source = $this->getSource();
+            if(method_exists($source, 'getFilePath')) {
+                $path = $source->getFilePath($this->type, $this->name);
+            } else {
+                $path = $source->getName();
+            }
             throw new ValueNotFoundException($attribute, get_class($this), $path);
         }
 


### PR DESCRIPTION
When the source is a database, the following error occurs.

```
Call to undefined method Whitecube\NovaPage\Sources\Database::getFilePath()
```

This PR will fix this error.