### PR TITLE
Use proper syntax highlighting type for Blade code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ protected $routeMiddleware = [
 
 Retrieving the page's static values in your application's blade templates is possible with the `get` directive or using the `Page` facade.
 
-```php
+```blade
 <p>@get('title')</p>
 
 // or


### PR DESCRIPTION
GitHub’s code highlighting feature [supports Blade](https://github.com/github/linguist/blob/master/vendor/README.md). Now the example code block in the README doesn’t look weird anymore :-)

Details 👌