### PR TITLE
Added novaPageIndexQuery to StaticResource to mimic indexQuery

### DIFF
--- a/src/Pages/Concerns/QueriesResources.php
+++ b/src/Pages/Concerns/QueriesResources.php
@@ -3,6 +3,7 @@
 namespace Whitecube\NovaPage\Pages\Concerns;
 
 use Route;
+use Whitecube\NovaPage\Pages\Query;
 use Whitecube\NovaPage\Pages\Template;
 use Whitecube\NovaPage\Pages\PageResource;
 use Whitecube\NovaPage\Pages\OptionResource;
@@ -19,7 +20,9 @@ trait QueriesResources
      */
     public function queryIndexResources(ResourceIndexRequest $request, $type) {
         $query = $this->newQueryWithoutScopes();
-        return $query->whereType($type)->get(false)->map(function($template) use ($type) {
+        $query->whereType($type);
+        $this->applyIndexQueryForType($type, $query);
+        return $query->get(false)->map(function($template) use ($type) {
             return $this->getResourceForType($type, $template);
         });
     }
@@ -47,6 +50,15 @@ trait QueriesResources
         switch ($type) {
             case 'route': return new PageResource($resource);
             case 'option': return new OptionResource($resource);
+        }
+    }
+
+    protected function applyIndexQueryForType($type, Query $query) {
+        $page_resource_class = config('novapage.default_page_resource');
+        $option_resource_class = config('novapage.default_option_resource');
+        switch ($type) {
+            case 'route': return $page_resource_class::novaPageIndexQuery($query);
+            case 'option': return $option_resource_class::novaPageIndexQuery($query);
         }
     }
 }

--- a/src/Pages/Query.php
+++ b/src/Pages/Query.php
@@ -30,6 +30,16 @@ class Query
     protected $type;
 
     /**
+     * The column to order by
+     */
+    protected $orderColumn;
+
+    /**
+     * The direction to order by
+     */
+    protected $orderDirection;
+
+    /**
      * The locale filter used to retrieve the resource
      *
      * @var null|string
@@ -71,6 +81,19 @@ class Query
     }
 
     /**
+     * Mimic eloquent's Builder and register a orderBy statment
+     *
+     * @param mixed $column
+     * @param string $direction
+     */
+    public function orderBy($column, string $direction = 'ASC')
+    {
+        $this->orderColumn = $column;
+        $this->orderDirection = $direction;
+        return $this;
+    }
+
+    /**
      * Mimic eloquent's Builder and return corresponding Resource
      *
      * @return mixed
@@ -97,7 +120,7 @@ class Query
     {
         $resources = $this->repository->getFiltered(trim($this->type . '.*', '.'));
 
-        return Collection::make($resources)
+        $result = Collection::make($resources)
             ->map(function($template, $key) {
                 return $this->repository->getResourceTemplate($key);
             })
@@ -107,6 +130,12 @@ class Query
                 list($type, $name) = explode('.', $key, 2);
                 return $this->repository->load($type, $name, $this->locale, $throwOnMissing);
             });
+
+        if ($this->orderColumn && $this->orderDirection) {
+            $result = $result->sortBy($this->orderColumn, SORT_REGULAR, ($this->orderDirection === 'DESC') ? true : false);
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Pages/StaticResource.php
+++ b/src/Pages/StaticResource.php
@@ -2,6 +2,7 @@
 
 namespace Whitecube\NovaPage\Pages;
 
+use App\Scopes\People\PrimaryClubPersonScope;
 use Laravel\Nova\Resource;
 use Laravel\Nova\Fields\ID;
 use Illuminate\Http\Request;
@@ -102,6 +103,17 @@ abstract class StaticResource extends Resource
             $this->getFormIntroductionFields(),
             $this->getTemplateAttributesFields($request)
         );
+    }
+
+    /**
+     * A blank method which allows index queries to be manipulated by the Resource
+     *
+     * @param Query $query
+     * @return Query
+     */
+    public static function novaPageIndexQuery(Query $query)
+    {
+        return $query;
     }
 
     /**


### PR DESCRIPTION
I've added a method `novaPageIndexQuery` to `Whitecube\NovaPage\Pages\StaticResource` which allows someone to manipulate the `Whitecube\NovaPage\Pages\Query` on the nova index page. It's intended to mimic the `indexQuery` method.

I've also added the method`Whitecube\NovaPage\Pages\Query::sortBy` to allow simple sorting.

*It might* work better just having a generic callback (e.g. `$query->setCallback(...)`) which gets applied to the Collection in `Whitecube\NovaPage\Pages\Query::get`.

~Should merge in conjunction with https://github.com/whitecube/nova-page/pull/45~ merged

#### Closes
https://github.com/whitecube/nova-page/issues/44 (sorta) 

#### Usage
Configure your own config `novapage.default_page_resource` in `config/novapage.php`
```
    'default_page_resource' => \App\Nova\Page::class,
```
```
<?php

namespace App\Nova;

use Whitecube\NovaPage\Pages\PageResource;
use Whitecube\NovaPage\Pages\Query;

class Page extends PageResource
{
    public static function novaPageIndexQuery(Query $query)
    {
        return $query->orderBy(function ($item) {
            return $item->getTitle();
        }, 'ASC');
    }
}

```