### PR TITLE
Register templates into the Laravel service container as well

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -140,7 +140,7 @@ Most websites or applications have repeated content, such as a copyright or cont
 
 First, create a regular `Template` as described above (e.g.: `php artisan make:template FooterOptions`) and fill the template's `fields()` method with all the wanted Nova fields.
 
-Now, register the template in NovaPage's Manager using the `register(string $type = 'option' | 'route', string $name, string $template)`. A good place to do this is in a ServiceProvider's `boot` method:
+Now, register the template in NovaPage's Manager using the `registerOption(string $name, string $template)`. A good place to do this is in a ServiceProvider's `boot` method:
 
 ```php
 use Whitecube\NovaPage\Pages\Manager;
@@ -150,7 +150,7 @@ class AppServiceProvider extends ServiceProvider
 {
     public function boot(Manager $pages)
     {
-        $pages->register('option', 'footer', \App\Nova\Templates\FooterOptions::class);
+        $pages->registerOption('footer', \App\Nova\Templates\FooterOptions::class);
     }
 }
 ```

--- a/src/Pages/Manager.php
+++ b/src/Pages/Manager.php
@@ -46,7 +46,8 @@ class Manager
     }
 
     /**
-     * Register a Template into the TemplatesRepository.
+     * Register a Template into the TemplatesRepository
+     * and to the Laravel service container as well.
      *
      * @param string $type
      * @param string $name
@@ -55,7 +56,25 @@ class Manager
      */
     public function register($type, $name, $template)
     {
+        app()->bind($template, function () use ($name) {
+            return $this->option($name);
+        });
+
         return $this->repository->register($type, $name, $template);
+    }
+
+    /**
+     * Register an option Template into the TemplatesRepository
+     * and to the Laravel service container as well.
+     *
+     * @param string $type
+     * @param string $name
+     * @param string $template
+     * @return Whitecube\NovaPage\Pages\Template
+     */
+    public function registerOption($name, $template)
+    {
+        return $this->register('option', $name, $template);
     }
 
     /**


### PR DESCRIPTION
This PR introduces two changes to make it more comfortable to work with options:

1. Registers templates to the Laravel service container, so you can use Laravel's dependency injection (and also automatic facades) to comfortably access your global options from controllers and such.

    This happens when you call `Manager::register`.
    
    Here's an example that works in this PR:

    ```php
    Route::get('/', function (FooterOptions $footerOptions) {
        return view('home', [
            'copyright' => $footerOptions->copyright
        ]);
    });
    ```

2. Added `registerOption` function, an alias for `register('option', ...)`, to make it more obvious and easy to remember.