### PR TITLE
Uses app() function instead resolve() to avoid conflicts

### DIFF
--- a/src/Pages/StaticResource.php
+++ b/src/Pages/StaticResource.php
@@ -82,12 +82,12 @@ abstract class StaticResource extends Resource
     public static function newModel()
     {
         if(request()->resourceId) {
-            return resolve(Manager::class)
+            return app(Manager::class)
                 ->newQueryWithoutScopes()
                 ->whereKey(request()->resourceId)
                 ->firstOrFail();
         }
-        return resolve(Manager::class);
+        return app(Manager::class);
     }
 
     /**
@@ -202,7 +202,7 @@ abstract class StaticResource extends Resource
      */
     public function jsonSerialize()
     {
-        return $this->serializeWithId($this->resolveFields(resolve(NovaRequest::class)));
+        return $this->serializeWithId($this->resolveFields(app(NovaRequest::class)));
     }
 
     /**
@@ -216,7 +216,7 @@ abstract class StaticResource extends Resource
         return [
             'id' => tap(ID::make('id', function() {
                         return $this->getKey();
-                    }))->resolve($this->resource),
+                    }))->app($this->resource),
             'fields' => $fields->all(),
         ];
     }

--- a/src/Pages/Template.php
+++ b/src/Pages/Template.php
@@ -27,7 +27,7 @@ abstract class Template implements ArrayAccess
 
     /**
      * The template key, used to identify it
-     * 
+     *
      * @var string
      */
     protected $key;
@@ -457,7 +457,7 @@ abstract class Template implements ArrayAccess
      */
     public function newQueryWithoutScopes()
     {
-        return resolve(Manager::class)->newQueryWithoutScopes();
+        return app(Manager::class)->newQueryWithoutScopes();
     }
 
     /**

--- a/src/Sources/Filesystem.php
+++ b/src/Sources/Filesystem.php
@@ -68,7 +68,7 @@ class Filesystem implements SourceInterface
         $data['attributes'] = $template->getAttributes();
 
         $path = $this->getOriginal($template);
-        
+
         $this->makeDirectory($path);
 
         return file_put_contents($path, json_encode($data, JSON_PRETTY_PRINT, 512));
@@ -110,7 +110,7 @@ class Filesystem implements SourceInterface
      */
     protected function makeDirectory($path)
     {
-        $files = resolve(BaseFilesystem::class);
+        $files = app(BaseFilesystem::class);
 
         if(!$files->isDirectory(dirname($path))) {
             $files->makeDirectory(dirname($path), 0755, true, true);


### PR DESCRIPTION
Figured out that a lot of other packages do have functions with the same name as `resolve` function. 

That was causing the page not to load properly. 
Since `resolve` itself it's just an alias for the real `app` function, I changed it accordingly and works like a charm now. 