### PR TITLE
Added model property to StaticResource

### DIFF
--- a/src/Pages/StaticResource.php
+++ b/src/Pages/StaticResource.php
@@ -13,6 +13,13 @@ abstract class StaticResource extends Resource
     use Concerns\ResolvesResourceFields;
 
     /**
+     * The model the resource corresponds to.
+     *
+     * @var string
+     */
+    public static $model;
+
+    /**
      * The single value that should be used to represent the resource when being displayed.
      *
      * @var string


### PR DESCRIPTION
The absence of the model property causes some problems. It's currently not possible to attach related records via Nova. It also breaks other third-party Nova tools, like the nova csv import tool.

This PR fixes this by adding the model property to the StaticResource abstract class.

Issue related to this:
#33