### PR TITLE
Made navigation links on the side bar localizable

### DIFF
--- a/resources/views/navigation.blade.php
+++ b/resources/views/navigation.blade.php
@@ -5,7 +5,7 @@
     }
 }" class="cursor-pointer flex items-center font-normal dim text-white mb-6 text-base no-underline">
     <svg class="sidebar-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="var(--sidebar-icon)" d="M6 2h9a1 1 0 0 1 .7.3l4 4a1 1 0 0 1 .3.7v13a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V4c0-1.1.9-2 2-2zm9 2.41V7h2.59L15 4.41zM18 9h-3a2 2 0 0 1-2-2V4H6v16h12V9zm-2 7a1 1 0 0 1-1 1H9a1 1 0 0 1 0-2h6a1 1 0 0 1 1 1zm0-4a1 1 0 0 1-1 1H9a1 1 0 0 1 0-2h6a1 1 0 0 1 1 1zm-5-4a1 1 0 0 1-1 1H9a1 1 0 1 1 0-2h1a1 1 0 0 1 1 1z"/></svg>
-    <span class="sidebar-label">{{ config('novapage.labels.pages') }}</span>
+    <span class="sidebar-label">{{ __(config('novapage.labels.pages')) }}</span>
 </router-link>
 <router-link tag="h3" :to="{
     name: 'index',
@@ -14,5 +14,5 @@
     }
 }" class="cursor-pointer flex items-center font-normal dim text-white mb-6 text-base no-underline">
     <svg class="sidebar-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="var(--sidebar-icon)" class="heroicon-ui" d="M9 4.58V4c0-1.1.9-2 2-2h2a2 2 0 0 1 2 2v.58a8 8 0 0 1 1.92 1.11l.5-.29a2 2 0 0 1 2.74.73l1 1.74a2 2 0 0 1-.73 2.73l-.5.29a8.06 8.06 0 0 1 0 2.22l.5.3a2 2 0 0 1 .73 2.72l-1 1.74a2 2 0 0 1-2.73.73l-.5-.3A8 8 0 0 1 15 19.43V20a2 2 0 0 1-2 2h-2a2 2 0 0 1-2-2v-.58a8 8 0 0 1-1.92-1.11l-.5.29a2 2 0 0 1-2.74-.73l-1-1.74a2 2 0 0 1 .73-2.73l.5-.29a8.06 8.06 0 0 1 0-2.22l-.5-.3a2 2 0 0 1-.73-2.72l1-1.74a2 2 0 0 1 2.73-.73l.5.3A8 8 0 0 1 9 4.57zM7.88 7.64l-.54.51-1.77-1.02-1 1.74 1.76 1.01-.17.73a6.02 6.02 0 0 0 0 2.78l.17.73-1.76 1.01 1 1.74 1.77-1.02.54.51a6 6 0 0 0 2.4 1.4l.72.2V20h2v-2.04l.71-.2a6 6 0 0 0 2.41-1.4l.54-.51 1.77 1.02 1-1.74-1.76-1.01.17-.73a6.02 6.02 0 0 0 0-2.78l-.17-.73 1.76-1.01-1-1.74-1.77 1.02-.54-.51a6 6 0 0 0-2.4-1.4l-.72-.2V4h-2v2.04l-.71.2a6 6 0 0 0-2.41 1.4zM12 16a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm0-2a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"/></svg>
-    <span class="sidebar-label">{{ config('novapage.labels.options') }}</span>
+    <span class="sidebar-label">{{ __(config('novapage.labels.options')) }}</span>
 </router-link>

--- a/src/config.php
+++ b/src/config.php
@@ -8,6 +8,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | How should we name the links in Laravel Nova's sidebar?
+	| Note that translation keys can be used instead of plain text.
     |
     */
     'labels' => [

--- a/src/config.php
+++ b/src/config.php
@@ -8,7 +8,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | How should we name the links in Laravel Nova's sidebar?
-	| Note that translation keys can be used instead of plain text.
+    | Note that translation keys can be used instead of plain text.
     |
     */
     'labels' => [


### PR DESCRIPTION
Laravel reads config files before the Translator class is initialized, so config options must be localized on the view level

Signed-off-by: CaddyDz <caddydz4@gmail.com>