### PR TITLE
Add preventsAccessingMissingAttributes method on template

### DIFF
--- a/src/Pages/Template.php
+++ b/src/Pages/Template.php
@@ -519,4 +519,15 @@ abstract class Template implements ArrayAccess
         return $this->raw;
     }
 
+    
+    /**
+     * Determine if accessing missing attributes is disabled.
+     *
+     * @return bool
+     */
+    public static function preventsAccessingMissingAttributes()
+    {
+        return Model::preventsAccessingMissingAttributes();
+    }
+
 }


### PR DESCRIPTION
This fixes the following error which is caused by Nova calling the `preventsAccessingMissingAttributes` on what it assumes is a model; when in fact it is not:

![CleanShot 2024-03-20 at 17 12 39@2x](https://github.com/whitecube/nova-page/assets/9298484/d7e86b43-a1d8-448e-b733-bead9a18bbb9)
